### PR TITLE
Ms12 automaitc spotify api authorisation

### DIFF
--- a/app/src/Components/LinkButton.tsx
+++ b/app/src/Components/LinkButton.tsx
@@ -1,17 +1,23 @@
 import { Button } from "@mui/material";
 import React from "react";
+import { useNavigate } from "react-router-dom";
+import { routes } from "../Constants/Routes";
 
 interface LinkButtonProps {
-  onClick?: () => void;
   text?: string;
-  href: string;
+  route: string;
 }
 
-const LinkButton: React.FC<LinkButtonProps> = ({ onClick, text, href }) => {
+const LinkButton: React.FC<LinkButtonProps> = ({ text, route }) => {
+
+  const navigate = useNavigate();
+  const onClickButton = () => {
+    navigate(route);
+  }
+
   return (
     <Button
-      onClick={onClick}
-      href={href}
+      onClick={onClickButton}
       sx={{
         color: "#656565",
         display: "block",

--- a/app/src/Constants/SpotifyAPI.ts
+++ b/app/src/Constants/SpotifyAPI.ts
@@ -1,6 +1,6 @@
 export const spotifyAPI = {
     clientId: '44deba64e2b04230a4e7c818ca419918',
-    redirectUri: 'http://localhost:3000/music/personalisedSpotify',
+    redirectUri: 'http://localhost:3000/music',
     scope: 'user-read-private user-read-email user-top-read user-read-recently-played playlist-read-private',
     authoriseUrl: 'https://accounts.spotify.com/authorize?',
     

--- a/app/src/Pages/Music/PersonalisedSpotify/index.tsx
+++ b/app/src/Pages/Music/PersonalisedSpotify/index.tsx
@@ -2,10 +2,9 @@ import React from "react";
 import { Box, Button } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import createTheme from "@mui/material/styles/createTheme";
-// import { fetchSpotifyApiAuthorisation } from "../../../Store/SpotifyAPI/tokenRequest";
 import { getProfile } from "../../../Store/SpotifyAPI/getProfile";
 import { refreshAccessToken } from "../../../Store/SpotifyAPI/refreshAccessToken";
-import { CodeVerifier } from "../../../Store/SpotifyAPI/authorisationRequest";
+import { AuthorisationRequest } from "../../../Store/SpotifyAPI/authorisationRequest";
 import { useTranslation } from "react-i18next";
 
 const PersonalisedSpotify: React.FC = () => {
@@ -16,7 +15,7 @@ const PersonalisedSpotify: React.FC = () => {
   //refresh api calls to happen automatically 
 
   const initalAuthorisaton = React.useCallback(() => {
-    CodeVerifier();
+    AuthorisationRequest();
   }, []);
 
   const getUserProfile = React.useCallback(() => {
@@ -27,13 +26,25 @@ const PersonalisedSpotify: React.FC = () => {
     refreshAccessToken();
   }, []);
 
+  const hasUserAuthorised = localStorage.getItem('access_token')
+  
+
+
   return (
     <Box className={styles.pageParameters}>
+      {hasUserAuthorised  ?
+       <>
+       <Button onClick={getUserProfile}>{t("getProfile")}</Button>
+       <Button onClick={refreshToken}>{t("refreshToken")}</Button>
+       </>
+       :
+      <>
       <Button onClick={initalAuthorisaton}>{t("initialAuthorisation")}</Button>
+      </>
+      
+}
 
-      <Button onClick={getUserProfile}>{t("getProfile")}</Button>
-
-      <Button onClick={refreshToken}>{t("refreshToken")}</Button>
+  
     </Box>
   );
 };

--- a/app/src/Pages/Music/index.tsx
+++ b/app/src/Pages/Music/index.tsx
@@ -7,6 +7,7 @@ import { TopSongsList } from "./TopSongsList";
 import { useTranslation } from "react-i18next";
 import { LinkButton } from "../../Components/LinkButton";
 import { routes } from "../../Constants/Routes";
+import { fetchTokenRequest } from "../../Store/SpotifyAPI/fetchTokenRequest";
 
 const Music: React.FC = () => {
   const styles = useStyles();
@@ -15,12 +16,16 @@ const Music: React.FC = () => {
   const { t } = useTranslation("music");
   const{t:tyear} = useTranslation("numbersAndDates")
 
+  React.useEffect(() => {
+    fetchTokenRequest()
+  },[])
+
   return (
     <>
      <Box className={styles.links}>
         <LinkButton 
-        href={routes.personalisedSpotify}
         text={t('spotifyApi')}
+        route={routes.personalisedSpotify}
         />
       </Box>
     <Box className={styles.pageParameters}>

--- a/app/src/Store/SpotifyAPI/authorisationRequest.ts
+++ b/app/src/Store/SpotifyAPI/authorisationRequest.ts
@@ -3,7 +3,7 @@ import { generateCodeChallenge } from "./codeChallenger";
 import { spotifyAPI } from "../../Constants/SpotifyAPI";
 import { apiEndpoints } from "../../Constants/Endpoints";
 
-export const CodeVerifier = () => {
+export const AuthorisationRequest = () => {
 let codeVerifier = generateRandomString(128);
 //Authorisation step 
 generateCodeChallenge(codeVerifier).then(codeChallenge => {
@@ -20,43 +20,4 @@ generateCodeChallenge(codeVerifier).then(codeChallenge => {
   });
   window.location.href = spotifyAPI.authoriseUrl + args;
 });
-
-//extracting the authorisation code 
-const urlParams = new URLSearchParams(window.location.search);
-let code = urlParams.get('code');
-let codeVerifiers = localStorage.getItem('code_verifier')
-
-//setting up body needed for token request 
-let body = new URLSearchParams({
-  grant_type: 'authorization_code',
-  code: code || '',
-  redirect_uri: spotifyAPI.redirectUri,
-  client_id: spotifyAPI.clientId,
-  code_verifier: codeVerifiers || ''
-});
-
-const tokenUrl = apiEndpoints.spotifyTokenRequest
-
-//token request
-fetch(tokenUrl, {
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/x-www-form-urlencoded'
-  },
-  body: body
-})
-  .then(response => {
-    if (!response.ok) {
-      throw new Error('HTTP status ' + response.status);
-    }
-    return response.json();
-  })
-  .then(data => {
-    localStorage.setItem('access_token', data.access_token);
-    localStorage.setItem('refresh_token', data.refresh_token);
-  })
-  .catch(error => {
-    console.error('Error:', error);
-  });
-
 }

--- a/app/src/Store/SpotifyAPI/fetchTokenRequest.ts
+++ b/app/src/Store/SpotifyAPI/fetchTokenRequest.ts
@@ -2,9 +2,8 @@ import { spotifyAPI } from "../../Constants/SpotifyAPI";
 
 export const fetchTokenRequest = () => {
   const searchParams = new URLSearchParams(window.location.search);
-  console.log('no code')
+  
   if (searchParams.has("code")) {
-    console.log('code')
     const codeVerifiers = localStorage.getItem("code_verifier");
     const code = searchParams.get('code')
 
@@ -34,3 +33,6 @@ export const fetchTokenRequest = () => {
       })
   }
 };
+
+//first we check if the url has a query parameter 'code' - if it does, extract it and save to local storage 
+//then pass this in the body of our token request 

--- a/app/src/Store/SpotifyAPI/fetchTokenRequest.ts
+++ b/app/src/Store/SpotifyAPI/fetchTokenRequest.ts
@@ -1,0 +1,36 @@
+import { spotifyAPI } from "../../Constants/SpotifyAPI";
+
+export const fetchTokenRequest = () => {
+  const searchParams = new URLSearchParams(window.location.search);
+  console.log('no code')
+  if (searchParams.has("code")) {
+    console.log('code')
+    const codeVerifiers = localStorage.getItem("code_verifier");
+    const code = searchParams.get('code')
+
+    fetch("https://accounts.spotify.com/api/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code: code || "",
+        redirect_uri: spotifyAPI.redirectUri,
+        client_id: spotifyAPI.clientId,
+        code_verifier: codeVerifiers || "",
+      }),
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("HTTP status " + response.status);
+          //need to do error handling for this 
+        }
+        return response.json();
+      })
+      .then((data) => {
+        localStorage.setItem("access_token", data.access_token);
+        localStorage.setItem("refresh_token", data.refresh_token);
+      })
+  }
+};

--- a/app/src/Store/SpotifyAPI/refreshAccessToken.ts
+++ b/app/src/Store/SpotifyAPI/refreshAccessToken.ts
@@ -2,13 +2,12 @@ import { apiEndpoints } from "../../Constants/Endpoints";
 
 export const refreshAccessToken = () => {
     const refreshToken = localStorage.getItem('refresh_token');
-    let body = new URLSearchParams({
+    const tokenUrl = apiEndpoints.spotifyTokenRequest
+    const body = new URLSearchParams({
         grant_type: 'refresh_token',
         refresh_token: refreshToken == null ? '' : refreshToken,
         client_id: '44deba64e2b04230a4e7c818ca419918'
     })
-
-    const tokenUrl = apiEndpoints.spotifyTokenRequest
 
 fetch(tokenUrl, {
   method: 'POST',
@@ -30,5 +29,4 @@ fetch(tokenUrl, {
   .catch(error => {
     console.error('Error:', error);
   });
-
 }


### PR DESCRIPTION
- When a user goes to the personalised spotify page, if they haven't authorised access, there will be a button they can click to take them to authorisation page, and start the authorisation process
- If they accept, are redirected back to the music page with a code in the url 
- Have a useEffect on the music pga checking for a 'code' parameter in the url 
- If present, it will call the fetchToken() function, which gets us the access and refresh token from spotify 
- When they go back to the personalised spotify page, have conditional logic checking lcoal storage for whether we have an access token stored - if we do, displays page without the button to authorise 
- so after first authorisation, should not display the button to request authorisation ever again


NOTE: The way it is set up at the moment, the fetchToken() that is called on the music page only works in production build. At the moment, believe it errors in dev env because it sends two api calls. One goes through fine, the other errors and stops the app. Think it's because the authorisation coded sent in the token request is one-time use - so on the second api call, the code is is not valid and errors. 

For testing purposes, switch to build mode if testing initial authorisation. 