### PR TITLE
MS11 Added useEffect for refresh token

### DIFF
--- a/app/src/Pages/Music/PersonalisedSpotify/index.tsx
+++ b/app/src/Pages/Music/PersonalisedSpotify/index.tsx
@@ -86,7 +86,4 @@ const useStyles = makeStyles({
 });
 
 export { PersonalisedSpotify };
-  function getUserSpotifyData() {
-    throw new Error("Function not implemented.");
-  }
 

--- a/app/src/Pages/Music/PersonalisedSpotify/index.tsx
+++ b/app/src/Pages/Music/PersonalisedSpotify/index.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 const PersonalisedSpotify: React.FC = () => {
   const styles = useStyles();
   const { t } = useTranslation("personalisedSpotify");
+  const hasUserAuthorised = localStorage.getItem('access_token')
 
   //this is just an initial setup for me to messa around with - will need to be updated and styled properly +
   //refresh api calls to happen automatically 
@@ -26,7 +27,12 @@ const PersonalisedSpotify: React.FC = () => {
     refreshAccessToken();
   }, []);
 
-  const hasUserAuthorised = localStorage.getItem('access_token')
+  //only works in prod - comment out and use buttons below for dev
+  // React.useEffect (() => {
+  //   if (hasUserAuthorised){
+  //     refreshAccessToken()
+  //   }
+  // },[hasUserAuthorised])
   
 
 
@@ -80,3 +86,7 @@ const useStyles = makeStyles({
 });
 
 export { PersonalisedSpotify };
+  function getUserSpotifyData() {
+    throw new Error("Function not implemented.");
+  }
+

--- a/app/src/Pages/Music/index.tsx
+++ b/app/src/Pages/Music/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, Typography } from "@mui/material";
+import { Box, Button, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import createTheme from "@mui/material/styles/createTheme";
 import { TopDnb2023, TopRockMetal2023 } from "../../Constants/topSongsLists";
@@ -16,6 +16,7 @@ const Music: React.FC = () => {
   const { t } = useTranslation("music");
   const{t:tyear} = useTranslation("numbersAndDates")
 
+  //only works in prod - comment out and use button below for dev
   React.useEffect(() => {
     fetchTokenRequest()
   },[])
@@ -28,6 +29,7 @@ const Music: React.FC = () => {
         route={routes.personalisedSpotify}
         />
       </Box>
+      {/* <Button onClick = {() => {fetchTokenRequest()}}></Button> */}
     <Box className={styles.pageParameters}>
       <Box className={styles.title}>
     <Typography variant="h1">{tyear('2023')}</Typography>

--- a/app/src/Store/SpotifyAPI/getProfile.ts
+++ b/app/src/Store/SpotifyAPI/getProfile.ts
@@ -2,9 +2,8 @@ import { apiEndpoints } from "../../Constants/Endpoints";
 
 async function getProfile() {
     let accessToken = localStorage.getItem('access_token');
-    const topTracksUrl = apiEndpoints.spotifyUserProfile
-  
-    const response = await fetch(topTracksUrl, {
+    const userProfileUrl = apiEndpoints.spotifyUserProfile
+    const response = await fetch(userProfileUrl, {
       headers: {
         Authorization: 'Bearer ' + accessToken
       }
@@ -13,5 +12,3 @@ async function getProfile() {
     return data
   }
   export {getProfile}
-
-  //most played track, favourite genres, favourite artists


### PR DESCRIPTION
once someone has authorised access to spotify and we have the access + refresh token, need to make it automatically refresh the token 

When the personalised spotify page loads have it automatically refresh the token (useEffect)

Plan is to eventually be: 

- spotify page loads - token refreshed - data fetched - data stored in redux for that session so no more api calls have to be made

NOTE: useEffect only works in prod build - so when in dev, have to use manual buttons to make the necessary api calls