### PR TITLE
MS16 Loading spotify data fetch automatically

### DIFF
--- a/app/src/Pages/Music/PersonalisedSpotify/index.tsx
+++ b/app/src/Pages/Music/PersonalisedSpotify/index.tsx
@@ -6,6 +6,7 @@ import { getProfile } from "../../../Store/SpotifyAPI/getProfile";
 import { refreshAccessToken } from "../../../Store/SpotifyAPI/refreshAccessToken";
 import { AuthorisationRequest } from "../../../Store/SpotifyAPI/authorisationRequest";
 import { useTranslation } from "react-i18next";
+import { fetchPersonalisedSpotifyData } from "../../../Store/SpotifyAPI/fetchPersonalisedSpotifyData";
 
 const PersonalisedSpotify: React.FC = () => {
   const styles = useStyles();
@@ -27,12 +28,12 @@ const PersonalisedSpotify: React.FC = () => {
     refreshAccessToken();
   }, []);
 
-  //only works in prod - comment out and use buttons below for dev
-  // React.useEffect (() => {
-  //   if (hasUserAuthorised){
-  //     refreshAccessToken()
-  //   }
-  // },[hasUserAuthorised])
+  // only works in prod - comment out and use buttons below for dev
+  React.useEffect (() => {
+    if (hasUserAuthorised){
+      fetchPersonalisedSpotifyData()
+    }
+  },[hasUserAuthorised])
   
 
 

--- a/app/src/Store/SpotifyAPI/fetchPersonalisedSpotifyData.ts
+++ b/app/src/Store/SpotifyAPI/fetchPersonalisedSpotifyData.ts
@@ -1,0 +1,8 @@
+import { getProfile } from "./getProfile";
+import { refreshAccessToken } from "./refreshAccessToken";
+
+export const fetchPersonalisedSpotifyData = () => {
+  refreshAccessToken().then(() => {
+    getProfile();
+  });
+};

--- a/app/src/Store/SpotifyAPI/refreshAccessToken.ts
+++ b/app/src/Store/SpotifyAPI/refreshAccessToken.ts
@@ -1,32 +1,31 @@
 import { apiEndpoints } from "../../Constants/Endpoints";
 
-export const refreshAccessToken = () => {
-    const refreshToken = localStorage.getItem('refresh_token');
-    const tokenUrl = apiEndpoints.spotifyTokenRequest
-    const body = new URLSearchParams({
-        grant_type: 'refresh_token',
-        refresh_token: refreshToken == null ? '' : refreshToken,
-        client_id: '44deba64e2b04230a4e7c818ca419918'
-    })
-
-fetch(tokenUrl, {
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/x-www-form-urlencoded'
-  },
-  body: body
-})
-  .then(response => {
-    if (!response.ok) {
-      throw new Error('HTTP status ' + response.status);
-    }
-    return response.json();
-  })
-  .then(data => {
-    localStorage.setItem('access_token', data.access_token);
-    localStorage.setItem('refresh_token', data.refresh_token);
-  })
-  .catch(error => {
-    console.error('Error:', error);
+export const refreshAccessToken = async () => {
+  const refreshToken = localStorage.getItem("refresh_token");
+  const tokenUrl = apiEndpoints.spotifyTokenRequest;
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: refreshToken == null ? "" : refreshToken,
+    client_id: "44deba64e2b04230a4e7c818ca419918",
   });
-}
+
+  const response = await fetch(tokenUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: body,
+  });
+  if (!response.ok) {
+    throw new Error("HTTP status " + response.status);
+  }
+  const data = await response.json();
+  localStorage.setItem("access_token", data.access_token);
+  localStorage.setItem("refresh_token", data.refresh_token);
+  return data;
+};
+
+
+//made this into an async function that returns a promise 
+//now that it returns a promise, we can call this function and then add on .then() - (once you've returned/await your promise, then do the following)
+//need this so that on load of spotify page, we call this function, and only once it is done, do we then then call the data from spotify 


### PR DESCRIPTION
- When loading the personalised Spotify page, want the refreshToken() to be called first - once that has completed, then make the api calls to get the users spotify data
- Have made the refreshToken() an async function that returns a promise 
- As a result, can then append .then() onto this - i.e. once the promise has been returned by this function, only then do the following 
- Then ask it to make the api call to fetch the users personal spotify data 