### PR TITLE
Ms18 change initial authorisation

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -12,6 +12,7 @@ import { theme } from "./Theme";
 import { store } from "./Store/configureStore";
 import { Provider } from 'react-redux'
 import { PersonalisedSpotifyRoute } from "./Routes/PersonalisedSpotify";
+import { MyProfileRoute } from "./Routes/MyProfileRoute";
 
 const muiTheme = createTheme(theme)
 
@@ -22,6 +23,7 @@ function AppRoutes() {
         <DrumAndBassRoute />
         <MusicRoute />
         <PersonalisedSpotifyRoute />
+        <MyProfileRoute />
     </>
   );
 }

--- a/app/src/Components/LinkButton.tsx
+++ b/app/src/Components/LinkButton.tsx
@@ -1,23 +1,22 @@
 import { Button } from "@mui/material";
 import React from "react";
 import { useNavigate } from "react-router-dom";
-import { routes } from "../Constants/Routes";
 
 interface LinkButtonProps {
   text?: string;
   route: string;
+  disabled?: boolean;
 }
 
-const LinkButton: React.FC<LinkButtonProps> = ({ text, route }) => {
-
+const LinkButton: React.FC<LinkButtonProps> = ({ text, route, disabled }) => {
   const navigate = useNavigate();
   const onClickButton = () => {
     navigate(route);
-  }
-
+  };
   return (
     <Button
       onClick={onClickButton}
+      disabled={disabled}
       sx={{
         color: "#656565",
         display: "block",

--- a/app/src/Components/PrimaryButton.tsx
+++ b/app/src/Components/PrimaryButton.tsx
@@ -1,21 +1,23 @@
 import { Button } from "@mui/material";
 import React from "react";
 
-interface LinkButtonProps {
+interface PrimaryButtonProps {
   onClick?: () => void;
   text?: string;
+  disabled?: boolean;
 }
 
-const PrimaryButton: React.FC<LinkButtonProps> = ({ onClick, text }) => {
+const PrimaryButton: React.FC<PrimaryButtonProps> = ({ onClick, text, disabled }) => {
   return (
     <Button
       onClick={onClick}
+      disabled={disabled}
       sx={{
-        color: "#f3efeb",
+        color: "white",
         display: "block",
-        bgcolor:  "#656565",
+        bgcolor: "#858585",
         ":hover": {
-          bgcolor:"#858585",
+          bgcolor: "#858585",
           color: "white",
         },
       }}

--- a/app/src/Constants/Routes.ts
+++ b/app/src/Constants/Routes.ts
@@ -2,7 +2,8 @@ export const routes = {
     music: "/music",
     dnb: "/music/dnb",
     home: "/",
-   personalisedSpotify: "/music/personalisedSpotify",
+    personalisedSpotify: "/music/personalisedSpotify",
+    myProfile: '/myProfile'
 
 
 }

--- a/app/src/Constants/SpotifyAPI.ts
+++ b/app/src/Constants/SpotifyAPI.ts
@@ -1,6 +1,6 @@
 export const spotifyAPI = {
     clientId: '44deba64e2b04230a4e7c818ca419918',
-    redirectUri: 'http://localhost:3000/music',
+    redirectUri: 'http://localhost:3000/myProfile',
     scope: 'user-read-private user-read-email user-top-read user-read-recently-played playlist-read-private',
     authoriseUrl: 'https://accounts.spotify.com/authorize?',
     

--- a/app/src/Layout/Navbar.tsx
+++ b/app/src/Layout/Navbar.tsx
@@ -28,6 +28,10 @@ const NavBar: React.FC = () => {
     }
   };
 
+  const navigateMyProfile = React.useCallback(() => {
+    navigate(routes.myProfile)
+  }, [navigate])
+
   return (
     <AppBar className={styles.navBar} sx={{ backgroundColor: "#858585" }}>
       <Container maxWidth="xl">
@@ -58,7 +62,9 @@ const NavBar: React.FC = () => {
             ))}
           </Box>
           <Box className={styles.userName}>
-            <AccountCircleIcon />
+            <AccountCircleIcon 
+            onClick= {navigateMyProfile}
+            />
             <Typography marginLeft={2}>{userName}</Typography>
           </Box>
         </Toolbar>

--- a/app/src/Pages/Music/PersonalisedSpotify/index.tsx
+++ b/app/src/Pages/Music/PersonalisedSpotify/index.tsx
@@ -4,7 +4,6 @@ import { makeStyles } from "@mui/styles";
 import createTheme from "@mui/material/styles/createTheme";
 import { getSpotifyUserProfile} from "../../../Store/SpotifyAPI/getSpotifyUserProfile";
 import { refreshAccessToken } from "../../../Store/SpotifyAPI/refreshAccessToken";
-import { AuthorisationRequest } from "../../../Store/SpotifyAPI/authorisationRequest";
 import { useTranslation } from "react-i18next";
 import { withRefreshAccessToken, withSpotifyUserPersonalData } from "../../../Store/SpotifyAPI/components";
 import { compose } from 'redux';
@@ -16,14 +15,9 @@ const PersonalisedSpotify = compose<React.FC> (
 ) (() => {
   const styles = useStyles();
   const { t } = useTranslation("personalisedSpotify");
-  const hasUserAuthorised = localStorage.getItem('access_token')
 
   //this is just an initial setup for me to messa around with - will need to be updated and styled properly +
   //refresh api calls to happen automatically 
-
-  const initalAuthorisaton = React.useCallback(() => {
-    AuthorisationRequest();
-  }, []);
 
   const getUserProfile = React.useCallback(() => {
     getSpotifyUserProfile();
@@ -40,23 +34,10 @@ const PersonalisedSpotify = compose<React.FC> (
   //   }
   // },[hasUserAuthorised])
   
-
-
   return (
     <Box className={styles.pageParameters}>
-      {hasUserAuthorised  ?
-       <>
        <Button onClick={getUserProfile}>{t("getProfile")}</Button>
        <Button onClick={refreshToken}>{t("refreshToken")}</Button>
-       </>
-       :
-      <>
-      <Button onClick={initalAuthorisaton}>{t("initialAuthorisation")}</Button>
-      </>
-      
-}
-
-  
     </Box>
   );
 });

--- a/app/src/Pages/Music/index.tsx
+++ b/app/src/Pages/Music/index.tsx
@@ -23,9 +23,7 @@ const Music: React.FC = () => {
   // },[])
 
   React.useEffect(() => {
-    const checkAccessToken = localStorage.getItem("access_token")
-      ? true
-      : false;
+    const checkAccessToken = localStorage.getItem("access_token") ? true : false;
     setHaveAccessToken(checkAccessToken);
   }, []);
 

--- a/app/src/Pages/Music/index.tsx
+++ b/app/src/Pages/Music/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, Button, Typography } from "@mui/material";
+import { Box, Tooltip, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import createTheme from "@mui/material/styles/createTheme";
 import { TopDnb2023, TopRockMetal2023 } from "../../Constants/topSongsLists";
@@ -14,35 +14,60 @@ const Music: React.FC = () => {
   const topDnb2023 = TopDnb2023();
   const topRockMetal2023 = TopRockMetal2023();
   const { t } = useTranslation("music");
-  const{t:tyear} = useTranslation("numbersAndDates")
+  const { t: tyear } = useTranslation("numbersAndDates");
+  const [haveAccessToken, setHaveAccessToken] = React.useState<boolean>(false);
 
   //only works in prod - comment out and use button below for dev
   // React.useEffect(() => {
   //   fetchTokenRequest()
   // },[])
 
+  React.useEffect(() => {
+    const checkAccessToken = localStorage.getItem("access_token")
+      ? true
+      : false;
+    setHaveAccessToken(checkAccessToken);
+  }, []);
+
   return (
     <>
-     <Box className={styles.links}>
-        <LinkButton 
-        text={t('spotifyApi')}
-        route={routes.personalisedSpotify}
-        />
+      <Box className={styles.links}>
+        {!haveAccessToken && (
+          <Tooltip title='Authorise Spotify access in the "My Profile" area'>
+            <span>
+              <LinkButton
+                text={t("yourSpotify")}
+                route={routes.personalisedSpotify}
+                disabled={!haveAccessToken}
+              />
+            </span>
+          </Tooltip>
+        )}
+        {haveAccessToken && (
+          <LinkButton
+            text={t("yourSpotify")}
+            route={routes.personalisedSpotify}
+            disabled={!haveAccessToken}
+          />
+        )}
       </Box>
       {/* <Button onClick = {() => {fetchTokenRequest()}}></Button> */}
-    <Box className={styles.pageParameters}>
-      <Box className={styles.title}>
-    <Typography variant="h1">{tyear('2023')}</Typography>
-    </Box>
-    <Box className={styles.mainContainer}>
-    <Box className={styles.listContainer}>
-      <TopSongsList songUrlList={topDnb2023} title={t("dnb")} />
-    </Box>
-    <Box className={styles.listContainer}>
-      <TopSongsList songUrlList={topRockMetal2023} title={t("rockMetal")} />
-    </Box>
-    </Box>
-    </Box>
+      <Box className={styles.pageParameters}>
+        <Box className={styles.title}>
+          <Typography variant="h1">{tyear("2023")}</Typography>
+        </Box>
+        <Box className={styles.mainContainer}>
+          <Box className={styles.listContainer}>
+            <TopSongsList songUrlList={topDnb2023} title={t("dnb")} />
+          </Box>
+          <Box className={styles.listContainer}>
+            <TopSongsList
+              songUrlList={topRockMetal2023}
+              title={t("rockMetal")}
+            />
+          </Box>
+        </Box>
+      </Box>
     </>
   );
 };
@@ -50,8 +75,8 @@ const Music: React.FC = () => {
 const theme = createTheme();
 const useStyles = makeStyles({
   pageParameters: {
-    width: '60%', 
-    marginLeft: '20%',
+    width: "60%",
+    marginLeft: "20%",
   },
   title: {
     justifyContent: "center",

--- a/app/src/Pages/MyProfile/index.tsx
+++ b/app/src/Pages/MyProfile/index.tsx
@@ -1,0 +1,61 @@
+import { Box, Typography } from "@mui/material";
+import { makeStyles } from "@mui/styles";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { PrimaryButton } from "../../Components/PrimaryButton";
+import { AuthorisationRequest } from "../../Store/SpotifyAPI/authorisationRequest";
+import { fetchTokenRequest } from "../../Store/SpotifyAPI/fetchTokenRequest";
+
+export const MyProfile: React.FC = () => {
+  const styles = useStyles();
+  const { t } = useTranslation("myProfile");
+  const [haveAccessToken, setHaveAccessToken] = React.useState<boolean>(false);
+
+  const fetchAuthorisation = React.useCallback(() => {
+    AuthorisationRequest();
+  }, []);
+
+  React.useEffect(() => {
+    fetchTokenRequest().then(() => {
+      const checkAccessToken = localStorage.getItem("access_token")
+        ? true
+        : false;
+      setHaveAccessToken(checkAccessToken);
+    });
+  }, []);
+
+  return (
+    <Box className={styles.listContainer}>
+        <Box marginBottom={4}>
+        <Typography variant="h1">{t('myProfile')}</Typography>
+        </Box>
+      <Typography variant="h3">{t('spotifyAuthorisation')}</Typography>
+      <Box className={styles.container} marginTop={2}>
+        <Typography variant="body1">
+            {haveAccessToken ?  t('haveAuthorised') :  t('spotifyDescription')}
+        </Typography>
+        <Box marginLeft={2}>
+        <PrimaryButton
+          text={t("authorise")}
+          onClick={fetchAuthorisation}
+          disabled={haveAccessToken}
+        />
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+const useStyles = makeStyles({
+  container: {
+    alignItems: "flex-start",
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  listContainer: {
+    alignItems: "flex-start",
+    display: "flex",
+    flexDirection: "column",
+  },
+});

--- a/app/src/Pages/MyProfile/index.tsx
+++ b/app/src/Pages/MyProfile/index.tsx
@@ -3,7 +3,7 @@ import { makeStyles } from "@mui/styles";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { PrimaryButton } from "../../Components/PrimaryButton";
-import { AuthorisationRequest } from "../../Store/SpotifyAPI/authorisationRequest";
+import { authorisationRequest } from "../../Store/SpotifyAPI/authorisationRequest";
 import { fetchTokenRequest } from "../../Store/SpotifyAPI/fetchTokenRequest";
 
 export const MyProfile: React.FC = () => {
@@ -12,14 +12,12 @@ export const MyProfile: React.FC = () => {
   const [haveAccessToken, setHaveAccessToken] = React.useState<boolean>(false);
 
   const fetchAuthorisation = React.useCallback(() => {
-    AuthorisationRequest();
+    authorisationRequest();
   }, []);
 
   React.useEffect(() => {
     fetchTokenRequest().then(() => {
-      const checkAccessToken = localStorage.getItem("access_token")
-        ? true
-        : false;
+      const checkAccessToken = localStorage.getItem("access_token") ? true : false;
       setHaveAccessToken(checkAccessToken);
     });
   }, []);

--- a/app/src/Routes/MyProfileRoute.tsx
+++ b/app/src/Routes/MyProfileRoute.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Route, Routes } from "react-router-dom";
+import { routes } from "../Constants/Routes";
+import { MyProfile } from "../Pages/MyProfile";
+
+export const MyProfileRoute: React.FC = () => {
+  return (
+    <Routes>
+      <Route path={routes.myProfile} element={<MyProfile />} />
+    </Routes>
+  );
+};

--- a/app/src/Store/SpotifyAPI/authorisationRequest.ts
+++ b/app/src/Store/SpotifyAPI/authorisationRequest.ts
@@ -2,7 +2,7 @@ import { generateRandomString } from "./codeVerifier";
 import { generateCodeChallenge } from "./codeChallenger";
 import { spotifyAPI } from "../../Constants/SpotifyAPI";
 
-export const AuthorisationRequest = () => {
+export const authorisationRequest = () => {
 let codeVerifier = generateRandomString(128);
 
 generateCodeChallenge(codeVerifier).then(codeChallenge => {

--- a/app/src/Store/SpotifyAPI/fetchTokenRequest.ts
+++ b/app/src/Store/SpotifyAPI/fetchTokenRequest.ts
@@ -7,7 +7,7 @@ export const fetchTokenRequest = () => {
     const codeVerifiers = localStorage.getItem("code_verifier");
     const code = searchParams.get("code");
 
-    fetch("https://accounts.spotify.com/api/token", {
+    return fetch("https://accounts.spotify.com/api/token", {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
@@ -32,4 +32,8 @@ export const fetchTokenRequest = () => {
         localStorage.setItem("refresh_token", data.refresh_token);
       });
   }
+  return Promise.resolve();
+  //just returning an empty promise here - so that even if there is no code in url, a promise of some sort is returned 
+  //if didn't have this, can' append .then() to fetchTokenRequest, as it can return either a Promise or undefined
+  //and can't apply .then() to something that returns undefined - only async operations that return a  promise
 };

--- a/app/src/TextFiles/music.ts
+++ b/app/src/TextFiles/music.ts
@@ -1,5 +1,5 @@
 export const music = {
     dnb: 'Dnb',
     rockMetal: 'Rock',
-    spotifyApi: 'spotify api'
+    yourSpotify: 'Your Spotify'
 }

--- a/app/src/TextFiles/myProfile.ts
+++ b/app/src/TextFiles/myProfile.ts
@@ -1,0 +1,8 @@
+export const myProfile = {
+    authorise: 'Authorise',
+    spotifyDescription: 'To access the "Your Spotify" page you need to give authorisation to use your personal Spotify data',
+    haveAuthorised: 'You have authorised access to your Spotify - thank you',
+    spotifyAuthorisation: 'Spotify Authorisation',
+    myProfile: 'My Profile'
+
+}

--- a/app/src/TextFiles/translations.ts
+++ b/app/src/TextFiles/translations.ts
@@ -4,6 +4,7 @@ import { numbersAndDates } from "./numbersAndDates";
 import { home } from "./home";
 import {navbar} from './navbar'
 import { personalisedSpotify } from "./personalisedSpotify";
+import { myProfile } from "./myProfile";
 
 
 export const enResources = {
@@ -13,4 +14,5 @@ export const enResources = {
   home: home,
   navbar: navbar,
   personalisedSpotify: personalisedSpotify,
+  myProfile: myProfile
 };

--- a/app/src/Theme/Overrides/Typography.ts
+++ b/app/src/Theme/Overrides/Typography.ts
@@ -13,6 +13,12 @@ export const typographyOverrides: Partial<Record<Variant, TypographyStyleOptions
     color: "#656565",
     fontFamily: 'Arial',
   },
+  h3: {
+    fontSize: 30,
+    fontWeight: 500,
+    color: "#656565",
+    fontFamily: 'Arial',
+  },
   body1: {
     fontSize: 20,
     lineHeight: 1.2,


### PR DESCRIPTION
link to personalised spotify should be disabled if no access token in local storage (i.e. user has not authorised spotify access)

Make user to go to my profile (click person icon top right), and in there have the initial authorisation button 

Disable this button if access token is found in local storage 

Reason is because with the HOC’s set up now, if someone goes onto that page the api calls will always fail 