### PR TITLE
MS35 Styling changes for mobile

### DIFF
--- a/app/src/Layout/Navbar.tsx
+++ b/app/src/Layout/Navbar.tsx
@@ -17,7 +17,9 @@ const NavBar: React.FC = () => {
   const { userName } = useUserName();
   const { t } = useTranslation("navbar");
 
-  const pages = [t("Muzik"), t("Merch")];
+  const pages = [t("Muzik"), 
+    // t("Merch")
+];
 
   const handleNavbarNavigation = (page: string) => {
     if (page === t("Muzik")) {
@@ -37,15 +39,9 @@ const NavBar: React.FC = () => {
 
   return (
     <AppBar className={styles.navBar} sx={{ backgroundColor: "#858585" }}>
-      <Toolbar
-        disableGutters
-        sx={{
-          ml: 4,
-          mr: 4,
-        }}
-      >
+      <Toolbar disableGutters sx={{ml: 2, mr:2}}>
         <NavBarButton onClick={navigateHome} text={t("home")} />
-        <Box sx={{ flexGrow: 1, display: { xs: "none", md: "flex" } }}>
+        <Box sx={{ flexGrow: 1, display: "flex"}}>
           {pages.map((page) => (
             <NavBarButton
               key={page}
@@ -75,11 +71,6 @@ const useStyles = makeStyles({
   userName: {
     display: "flex",
     justifyContent: "flex-end",
-  },
-  toolbar: {
-    padding: 2,
-    marginLeft: 2,
-    marginRight: 2,
-  },
+  }
 });
 export default NavBar;

--- a/app/src/Pages/Music/PersonalisedSpotify/index.tsx
+++ b/app/src/Pages/Music/PersonalisedSpotify/index.tsx
@@ -86,6 +86,9 @@ const useStyles = makeStyles({
     display: "flex",
     flexDirection: "row",
     justifyContent: "flex-start",
+    '@media (max-width: 600px)': {
+      flexDirection: 'column',
+    },
   },
   mainContainer: {
     alignItems: "flex-start",

--- a/app/src/Pages/Music/index.tsx
+++ b/app/src/Pages/Music/index.tsx
@@ -88,6 +88,9 @@ const useStyles = makeStyles({
     display: "flex",
     flexDirection: "row",
     justifyContent: "space-between",
+    '@media (max-width: 600px)': {
+      flexDirection: 'column', // Apply for screens up to 600px (xs screens)
+    },
   },
   listContainer: {
     padding: theme.spacing(4),


### PR DESCRIPTION
Have added ‘@media (max-width: 600px)’ to styling

means any styling contained within this will only become active if the screen size is less than 600px (like a mobile) 

navbar (will flex on xs)

Music page (list of songs will have flexDirection column, not row)

Personalised Spotify page (title and image + playlist name and image have flexDirection of column, not row)