### PR TITLE
Ms65 spotify react query

### DIFF
--- a/app/src/Constants/TextFiles/error.ts
+++ b/app/src/Constants/TextFiles/error.ts
@@ -1,4 +1,8 @@
 export const error  = {
     title: 'Oh bugger!',
-    description: 'Oops, looks like there was an error loading the page :/ please try again later'
+    description: 'Oops, looks like there was an error loading the page :/ please try again later',
+    invalidTokenDescription: 'There was an error authorising your connection to Spotify. Please go to the MyProfile section and authorise access to your Spotify (even if you have done so before).',
+    tokenExpiredDescription: 'There was an error fetching your Spotify data. Click the below button to refresh the connection to Spotify!',
+    refresh: 'Refresh',
+    refreshed: 'Spotify connection refreshed',
 }

--- a/app/src/Constants/TextFiles/queryKeys.ts
+++ b/app/src/Constants/TextFiles/queryKeys.ts
@@ -1,4 +1,9 @@
 export const queryKeys = {
-    getProducts: 'getProducts'
-
+    getProducts: 'getProducts',
+    spotifyUserProfile: 'spotifyUserProfile',
+    spotifyUserPlaylists: 'spotifyUserPlaylists',
+    spotifyUserTopArtists: 'spotifyUserTopArtists',
+    spotifyUserTopTracks: 'spotifyUserTopTracks',
+    spotifyUserAllTimeTopArtists: 'spotifyUserAllTimeTopArtists',
+    spotifyUserAllTimeTopTracks: 'spotifyUserAllTimeTopTracks',
 }

--- a/app/src/Constants/Types/Spotify.ts
+++ b/app/src/Constants/Types/Spotify.ts
@@ -20,3 +20,11 @@ export type spotifyUserPlaylists = [{
   name: string,
   imageUrl: string
 }]
+
+export type spotifyRefreshTokenResponse = {
+  access_token: string | undefined,
+  token_type: string,
+  expires_in: number,
+  refresh_token: string | undefined,
+  scope: string
+}

--- a/app/src/Hooks/useMutations.tsx
+++ b/app/src/Hooks/useMutations.tsx
@@ -42,6 +42,7 @@ export const useMutationDelete = (url: string, payload: any, key?: string) => {
 
 
 export const useMutationSpotifyPost = (url: string, key?: string) => {
+    const [snackbar, setSnackbar] = React.useState<boolean>(false);
     const queryClient = useQueryClient() 
     const refreshToken = localStorage.getItem("refresh_token");
     const payload = {
@@ -56,8 +57,9 @@ export const useMutationSpotifyPost = (url: string, key?: string) => {
             onSuccess: (data) => {
                 queryClient.invalidateQueries({queryKey: [key], refetchType: 'all'}), 
                 data?.access_token && localStorage.setItem("access_token", data.access_token),
-                data?.refresh_token && localStorage.setItem("refresh_token", data.refresh_token)
+                data?.refresh_token && localStorage.setItem("refresh_token", data.refresh_token),
+                setSnackbar(true)
             },
         })
-    return {mutation}
+    return {mutation, snackbar, setSnackbar}
 }

--- a/app/src/Hooks/useMutations.tsx
+++ b/app/src/Hooks/useMutations.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import React from "react";
+import { spotifyPost } from "../Store/apiStore";
 
 
 export const useMutationPost = (url: string, payload: any, key?: string) => {
@@ -9,7 +10,7 @@ export const useMutationPost = (url: string, payload: any, key?: string) => {
     
     const mutation = useMutation({
             mutationFn: () => {return axios.post(url, payload)},
-            onSuccess: () => {queryClient.invalidateQueries({queryKey: [key], refetchType: 'all'}), setSnackbar(true)},
+            onSuccess: () => {queryClient.invalidateQueries({queryKey: [key], refetchType: 'all'}), setSnackbar(true)}
         })
     return {mutation, snackbar, setSnackbar}
 }
@@ -38,3 +39,25 @@ export const useMutationDelete = (url: string, payload: any, key?: string) => {
 
 //By default invalidateQueries() only forces refetch for active queries, and for some reason the loader doesn't count as being "active", 
 //so I had to add the prop refetchType: 'all' to invalidateQueries()
+
+
+export const useMutationSpotifyPost = (url: string, key?: string) => {
+    const queryClient = useQueryClient() 
+    const refreshToken = localStorage.getItem("refresh_token");
+    const payload = {
+      grant_type: "refresh_token",
+      refresh_token: refreshToken == null ? "" : refreshToken,
+      client_id: "44deba64e2b04230a4e7c818ca419918",
+    }
+    
+    const mutation = useMutation({
+            mutationFn: () => {
+                return spotifyPost(url, payload)},
+            onSuccess: (data) => {
+                queryClient.invalidateQueries({queryKey: [key], refetchType: 'all'}), 
+                data?.access_token && localStorage.setItem("access_token", data.access_token),
+                data?.refresh_token && localStorage.setItem("refresh_token", data.refresh_token)
+            },
+        })
+    return {mutation}
+}

--- a/app/src/Hooks/useQueryGet.tsx
+++ b/app/src/Hooks/useQueryGet.tsx
@@ -15,6 +15,9 @@ interface Props {
   header?: object
 }
 
+const accessToken = localStorage.getItem("access_token")
+const header = { Authorization: "Bearer " + accessToken }
+
 export const useQueryGet = ({ url, key, enabled = true, header }: Props): UseQueryGet => {
   const getRequest = async () => await get(url, header)
   return useQuery({ queryKey: [key], queryFn: getRequest, enabled: enabled, refetchOnMount: false, refetchOnWindowFocus: false });
@@ -24,7 +27,7 @@ export const useQueryGet = ({ url, key, enabled = true, header }: Props): UseQue
 
 //decided to format the data within the useQuery requests as these are spcific for the spotify request, and won't be used anywhere else
 
-export const useQuerySpotifyUserProfile = ({ url, key, enabled = true, header }: Props): UseQueryGet => {
+export const useQuerySpotifyUserProfile = ({ url, key, enabled = true }: Props): UseQueryGet => {
   const getRequest = async () => {
     const data = await get(url, header)
     const formattedData: spotifyUserData = {
@@ -40,7 +43,7 @@ export const useQuerySpotifyUserProfile = ({ url, key, enabled = true, header }:
   return useQuery({ queryKey: [key], queryFn: getRequest, enabled: enabled, refetchOnMount: false, refetchOnWindowFocus: false });
 }
 
-export const useQuerySpotifyUserPlaylists = ({ url, key, enabled = true, header }: Props): UseQueryGet => {
+export const useQuerySpotifyUserPlaylists = ({ url, key, enabled = true }: Props): UseQueryGet => {
   const getRequest = async () => {
     const data = await get(url, header)
     const formattedData: spotifyUserPlaylists = data.items.map((playlist: any) => ({
@@ -52,7 +55,7 @@ export const useQuerySpotifyUserPlaylists = ({ url, key, enabled = true, header 
   return useQuery({ queryKey: [key], queryFn: getRequest, enabled: enabled, refetchOnMount: false, refetchOnWindowFocus: false });
 }
 
-export const useQuerySpotifyUserTopArtists = ({ url, key, enabled = true, header }: Props): UseQueryGet => {
+export const useQuerySpotifyUserTopArtists = ({ url, key, enabled = true }: Props): UseQueryGet => {
   const getRequest = async () => {
     const data = await get(url, header)
     const formattedData: spotifyUserTopArtist = {
@@ -64,7 +67,7 @@ export const useQuerySpotifyUserTopArtists = ({ url, key, enabled = true, header
 }
 
 
-export const useQuerySpotifyUserTopTracks = ({ url, key, enabled = true, header }: Props): UseQueryGet => {
+export const useQuerySpotifyUserTopTracks = ({ url, key, enabled = true }: Props): UseQueryGet => {
   const getRequest = async () => {
     const data = await get(url, header)
     const formattedData: spotifyUserTopTracks = data.items.map((track: any) => ({

--- a/app/src/Hooks/useQueryGet.tsx
+++ b/app/src/Hooks/useQueryGet.tsx
@@ -17,13 +17,12 @@ interface Props {
 }
 
 const accessToken = localStorage.getItem("access_token")
-const header = { Authorization: "Bearer " + '12345' }
+const header = { Authorization: "Bearer " + accessToken }
 
 export const useQueryGet = ({ url, key, enabled = true, header }: Props): UseQueryGet => {
   const getRequest = async () => await get(url, header)
   return useQuery({ queryKey: [key], queryFn: getRequest, enabled: enabled, refetchOnMount: false, refetchOnWindowFocus: false });
 }
-
 
 
 //decided to format the data within the useQuery requests as these are spcific for the spotify request, and won't be used anywhere else

--- a/app/src/Hooks/useQueryGet.tsx
+++ b/app/src/Hooks/useQueryGet.tsx
@@ -1,12 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { get } from "../Store/apiStore";
 import { spotifyUserData, spotifyUserPlaylists, spotifyUserTopArtist, spotifyUserTopTracks } from "../Constants/Types/Spotify";
-import { AnyAction } from "redux";
 
 interface UseQueryGet {
   data: any;
   error: Error | null;
   isPending: boolean;
+  isInitialLoading: boolean;
 }
 
 interface Props {
@@ -16,8 +16,6 @@ interface Props {
   header?: object
 }
 
-const accessToken = localStorage.getItem("access_token")
-const header = { Authorization: "Bearer " + accessToken }
 
 export const useQueryGet = ({ url, key, enabled = true, header }: Props): UseQueryGet => {
   const getRequest = async () => await get(url, header)
@@ -27,7 +25,9 @@ export const useQueryGet = ({ url, key, enabled = true, header }: Props): UseQue
 
 //decided to format the data within the useQuery requests as these are spcific for the spotify request, and won't be used anywhere else
 
-export const useQuerySpotifyUserProfile = ({ url, key, enabled = true }: Props): UseQueryGet => {
+export const useQuerySpotifyUserProfile = ({ url, key, enabled}: Props): UseQueryGet => {
+  const accessToken = localStorage.getItem("access_token")
+  const header = { Authorization: "Bearer " + accessToken }
   const getRequest = async () => {
     try {
       const data = await get(url, header)
@@ -42,7 +42,6 @@ export const useQuerySpotifyUserProfile = ({ url, key, enabled = true }: Props):
       return formattedData
     }
     catch (error: any) {
-      console.log(error)
       if (error.response.data.error.message == 'The access token expired') {
         throw new Error('Access token expired')
       }
@@ -58,19 +57,23 @@ export const useQuerySpotifyUserProfile = ({ url, key, enabled = true }: Props):
   return useQuery({ queryKey: [key], queryFn: getRequest, enabled: enabled, refetchOnMount: false, refetchOnWindowFocus: false });
 }
 
-export const useQuerySpotifyUserPlaylists = ({ url, key, enabled = true }: Props): UseQueryGet => {
+export const useQuerySpotifyUserPlaylists = ({ url, key, enabled }: Props): UseQueryGet => {
+  const accessToken = localStorage.getItem("access_token")
+  const header = { Authorization: "Bearer " + accessToken }
   const getRequest = async () => {
-    const data = await get(url, header)
-    const formattedData: spotifyUserPlaylists = data.items.map((playlist: any) => ({
-      name: playlist.name,
-      imageUrl: playlist.images ? playlist.images[0].url : null,
-    }));
-    return formattedData
+      const data = await get(url, header)
+      const formattedData: spotifyUserPlaylists = data.items.map((playlist: any) => ({
+        name: playlist.name,
+        imageUrl: playlist.images ? playlist.images[0].url : null,
+      }));
+      return formattedData
   }
   return useQuery({ queryKey: [key], queryFn: getRequest, enabled: enabled, refetchOnMount: false, refetchOnWindowFocus: false });
 }
 
-export const useQuerySpotifyUserTopArtists = ({ url, key, enabled = true }: Props): UseQueryGet => {
+export const useQuerySpotifyUserTopArtists = ({ url, key, enabled }: Props): UseQueryGet => {
+  const accessToken = localStorage.getItem("access_token")
+  const header = { Authorization: "Bearer " + accessToken }
   const getRequest = async () => {
     const data = await get(url, header)
     const formattedData: spotifyUserTopArtist = {
@@ -82,7 +85,9 @@ export const useQuerySpotifyUserTopArtists = ({ url, key, enabled = true }: Prop
 }
 
 
-export const useQuerySpotifyUserTopTracks = ({ url, key, enabled = true }: Props): UseQueryGet => {
+export const useQuerySpotifyUserTopTracks = ({ url, key, enabled}: Props): UseQueryGet => {
+  const accessToken = localStorage.getItem("access_token")
+  const header = { Authorization: "Bearer " + accessToken }
   const getRequest = async () => {
     const data = await get(url, header)
     const formattedData: spotifyUserTopTracks = data.items.map((track: any) => ({

--- a/app/src/Hooks/useQueryGet.tsx
+++ b/app/src/Hooks/useQueryGet.tsx
@@ -1,13 +1,77 @@
 import { useQuery } from "@tanstack/react-query";
 import { get } from "../Store/apiStore";
+import { spotifyUserData, spotifyUserPlaylists, spotifyUserTopArtist, spotifyUserTopTracks } from "../Constants/Types/Spotify";
 
 interface UseQueryGet {
-    data: any;
-    error: Error | null;
-    isPending: boolean;
-  }
+  data: any;
+  error: Error | null;
+  isPending: boolean;
+}
 
-export const useQueryGet = (url: string, key: string, refetchOnMount?: boolean, refetchOnWindowFocus?: boolean): UseQueryGet => {
-    const getRequest = async () => await get(url)
-    return useQuery({queryKey: [key], queryFn: getRequest, enabled: true, refetchOnMount: refetchOnMount, refetchOnWindowFocus: refetchOnWindowFocus});
+interface Props {
+  url: string,
+  key: string,
+  enabled?: boolean,
+  header?: object
+}
+
+export const useQueryGet = ({ url, key, enabled = true, header }: Props): UseQueryGet => {
+  const getRequest = async () => await get(url, header)
+  return useQuery({ queryKey: [key], queryFn: getRequest, enabled: enabled, refetchOnMount: false, refetchOnWindowFocus: false });
+}
+
+
+
+//decided to format the data within the useQuery requests as these are spcific for the spotify request, and won't be used anywhere else
+
+export const useQuerySpotifyUserProfile = ({ url, key, enabled = true, header }: Props): UseQueryGet => {
+  const getRequest = async () => {
+    const data = await get(url, header)
+    const formattedData: spotifyUserData = {
+      name: data.display_name,
+      email: data.email,
+      image: data.images[1].url,
+      country: data.country,
+      followers: data.followers.total,
+      explicitContent: data.explicit_content.filter_enabled,
+    }
+    return formattedData
+  }
+  return useQuery({ queryKey: [key], queryFn: getRequest, enabled: enabled, refetchOnMount: false, refetchOnWindowFocus: false });
+}
+
+export const useQuerySpotifyUserPlaylists = ({ url, key, enabled = true, header }: Props): UseQueryGet => {
+  const getRequest = async () => {
+    const data = await get(url, header)
+    const formattedData: spotifyUserPlaylists = data.items.map((playlist: any) => ({
+        name: playlist.name,
+        imageUrl: playlist.images ? playlist.images[0].url : null,
+      }));
+    return formattedData
+  }
+  return useQuery({ queryKey: [key], queryFn: getRequest, enabled: enabled, refetchOnMount: false, refetchOnWindowFocus: false });
+}
+
+export const useQuerySpotifyUserTopArtists = ({ url, key, enabled = true, header }: Props): UseQueryGet => {
+  const getRequest = async () => {
+    const data = await get(url, header)
+    const formattedData: spotifyUserTopArtist = {
+      name: data.items.map((artist: any) => artist.name),
+    }
+    return formattedData
+  }
+  return useQuery({ queryKey: [key], queryFn: getRequest, enabled: enabled, refetchOnMount: false, refetchOnWindowFocus: false });
+}
+
+
+export const useQuerySpotifyUserTopTracks = ({ url, key, enabled = true, header }: Props): UseQueryGet => {
+  const getRequest = async () => {
+    const data = await get(url, header)
+    const formattedData: spotifyUserTopTracks = data.items.map((track: any) => ({
+      song: track.name,
+      artist: track.artists[0].name,
+    }));
+    return formattedData
+  }
+  return useQuery({ queryKey: [key], queryFn: getRequest, enabled: enabled, refetchOnMount: false, refetchOnWindowFocus: false });
 }

--- a/app/src/Pages/Home/Home.tsx
+++ b/app/src/Pages/Home/Home.tsx
@@ -2,16 +2,26 @@ import React from "react";
 import { Box, Typography } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { styled } from '@mui/system';
+import { useMutationSpotifyPost } from "../../Hooks/useMutations";
+import { apiEndpoints } from "../../Store/Endpoints";
 
 const Home: React.FC = () => {
   const { t } = useTranslation("home");
-  
+  const { mutation } = useMutationSpotifyPost(apiEndpoints.spotifyTokenRequest)
+
+  React.useEffect(() => {
+    const checkToken = localStorage.getItem("access_token") ? true : false
+    if (checkToken) {
+      mutation.mutate()
+    }
+  }, [])
+
   return (
     <MainContainer>
-        <Typography variant="h1" data-test-id={"home-title"}>{t("welcome")}</Typography>
-        <Box marginTop={"2%"}>
-          <Typography variant="body1" data-test-id={"home-description"}>{t("welcomeMessage")}</Typography>
-        </Box>
+      <Typography variant="h1" data-test-id={"home-title"}>{t("welcome")}</Typography>
+      <Box marginTop={"2%"}>
+        <Typography variant="body1" data-test-id={"home-description"}>{t("welcomeMessage")}</Typography>
+      </Box>
     </MainContainer>
   );
 };

--- a/app/src/Pages/Merchandise/Merchandise.tsx
+++ b/app/src/Pages/Merchandise/Merchandise.tsx
@@ -12,8 +12,9 @@ import { routes } from "../../Constants/Routes/RoutesEndpoints";
 
 const Merchandise: React.FC = () => {
   const { t } = useTranslation("merchandise");
-
-  const { data: products, error, isPending } = useQueryGet(apiEndpoints.products, 'getProducts', false, false);
+  const {t: tkey} = useTranslation("queryKeys")
+  
+  const { data: products, error, isPending } = useQueryGet({url: apiEndpoints.products, key: tkey('getProducts')});
   if (isPending) return <LoadingCircle />
   if (error) return <Error />
 

--- a/app/src/Pages/MyProfile/MyProfile.tsx
+++ b/app/src/Pages/MyProfile/MyProfile.tsx
@@ -53,7 +53,6 @@ export const MyProfile: React.FC = () => {
             <PrimaryButton
               text={t("authorise")}
               onClick={fetchAuthorisation}
-              disabled={haveAccessToken}
             />
           </Box>
         </Container>

--- a/app/src/Pages/PersonalisedSpotify/ErrorInvalidToken.tsx
+++ b/app/src/Pages/PersonalisedSpotify/ErrorInvalidToken.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Box, Button, Typography } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { styled } from '@mui/system';
+import { useMutationSpotifyPost } from "../../Hooks/useMutations";
+import { apiEndpoints } from "../../Store/Endpoints";
+
+const ErrorInvalidToken: React.FC = () => {
+  const { t } = useTranslation("error");
+
+  const {mutation} = useMutationSpotifyPost(apiEndpoints.spotifyTokenRequest)
+
+  return (
+      <Container>
+        <Typography variant="h1">{t("title")}</Typography>
+        <Box marginTop={6}>
+          <Typography variant="body1">{t("description")}</Typography>
+        </Box>
+        <Typography>There was an error authorising your connection to Spotify. Please go to 
+            the MyProfile section and Authoris access to your Spotify. 
+        </Typography>
+      </Container>
+  );
+};
+
+const Container = styled('div')({
+  display: "flex",
+  alignItems: "center",
+  flexDirection: "column",
+});
+
+export { ErrorInvalidToken };

--- a/app/src/Pages/PersonalisedSpotify/ErrorInvalidToken.tsx
+++ b/app/src/Pages/PersonalisedSpotify/ErrorInvalidToken.tsx
@@ -1,24 +1,17 @@
 import React from "react";
-import { Box, Button, Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { styled } from '@mui/system';
-import { useMutationSpotifyPost } from "../../Hooks/useMutations";
-import { apiEndpoints } from "../../Store/Endpoints";
 
 const ErrorInvalidToken: React.FC = () => {
   const { t } = useTranslation("error");
-
-  const {mutation} = useMutationSpotifyPost(apiEndpoints.spotifyTokenRequest)
 
   return (
       <Container>
         <Typography variant="h1">{t("title")}</Typography>
         <Box marginTop={6}>
-          <Typography variant="body1">{t("description")}</Typography>
+          <Typography variant="body1">{t("invalidTokenDescription")}</Typography>
         </Box>
-        <Typography>There was an error authorising your connection to Spotify. Please go to 
-            the MyProfile section and Authoris access to your Spotify. 
-        </Typography>
       </Container>
   );
 };

--- a/app/src/Pages/PersonalisedSpotify/ErrorTokenExpired.tsx
+++ b/app/src/Pages/PersonalisedSpotify/ErrorTokenExpired.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Box, Button, Typography } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { styled } from '@mui/system';
+import { useMutationSpotifyPost } from "../../Hooks/useMutations";
+import { apiEndpoints } from "../../Store/Endpoints";
+
+const ErrorTokenExpired: React.FC = () => {
+  const { t } = useTranslation("error");
+
+  const {mutation} = useMutationSpotifyPost(apiEndpoints.spotifyTokenRequest)
+
+  return (
+      <Container>
+        <Typography variant="h1">{t("title")}</Typography>
+        <Box marginTop={6}>
+          <Typography variant="body1">{t("description")}</Typography>
+        </Box>
+        <Typography>Click the below button to refresh the connection to Spotify!</Typography>
+        <Button onClick={() => mutation.mutate()}>Refresh</Button>
+      </Container>
+  );
+};
+
+const Container = styled('div')({
+  display: "flex",
+  alignItems: "center",
+  flexDirection: "column",
+});
+
+export { ErrorTokenExpired };

--- a/app/src/Pages/PersonalisedSpotify/ErrorTokenExpired.tsx
+++ b/app/src/Pages/PersonalisedSpotify/ErrorTokenExpired.tsx
@@ -4,21 +4,46 @@ import { useTranslation } from "react-i18next";
 import { styled } from '@mui/system';
 import { useMutationSpotifyPost } from "../../Hooks/useMutations";
 import { apiEndpoints } from "../../Store/Endpoints";
+import { SnackBar } from "../../Components/SnackBar";
+import { LoadingCircle } from "../../Components/LoadingCircle";
+import { PrimaryButton } from "../../Components/PrimaryButton";
 
 const ErrorTokenExpired: React.FC = () => {
   const { t } = useTranslation("error");
 
-  const {mutation} = useMutationSpotifyPost(apiEndpoints.spotifyTokenRequest)
+  const {mutation, snackbar, setSnackbar} = useMutationSpotifyPost(apiEndpoints.spotifyTokenRequest)
+  const refreshToken = () => {
+    mutation.mutate()
+  }
 
   return (
+    <>
       <Container>
         <Typography variant="h1">{t("title")}</Typography>
         <Box marginTop={6}>
-          <Typography variant="body1">{t("description")}</Typography>
+          <Typography variant="body1">{t("tokenExpiredDescription")}</Typography>
         </Box>
-        <Typography>Click the below button to refresh the connection to Spotify!</Typography>
-        <Button onClick={() => mutation.mutate()}>Refresh</Button>
+        <PrimaryButton onClick={refreshToken} text={t('refresh')} />
       </Container>
+
+       <div>
+       {mutation.isPending ? (<LoadingCircle />) :
+         (
+           <>
+             {mutation.isError && (
+               <div>An error occurred: {mutation.error.message}</div>
+             )}
+             {mutation.isSuccess &&
+               <SnackBar
+                 snackbarActive={snackbar}
+                 setSnackbarActive={setSnackbar}
+                 message={t('refreshed')}
+               />}
+           </>
+
+         )}
+     </div>
+     </>
   );
 };
 

--- a/app/src/Pages/PersonalisedSpotify/PersonalisedSpotify.tsx
+++ b/app/src/Pages/PersonalisedSpotify/PersonalisedSpotify.tsx
@@ -15,24 +15,21 @@ import { ErrorInvalidToken } from "./ErrorInvalidToken";
 const PersonalisedSpotify: React.FC = () => {
 
   const { t } = useTranslation("personalisedSpotify");
-  const {t:tkey} = useTranslation("queryKeys")
+  const { t: tkey } = useTranslation("queryKeys")
 
-  const {data: userProfile, error: userProfileError, isPending: userProfilePending} = useQuerySpotifyUserProfile({url: apiEndpoints.spotifyUserProfile, key: tkey('spotifyUserProfile'), enabled: true})
-  const {data: userPlaylists, error: userPlaylistsError, isPending: userPlaylistsPending} = useQuerySpotifyUserPlaylists({url: apiEndpoints.spotifyUserPlaylists, key: tkey('spotifyUserPlaylists'), enabled: !!userProfile })
-  const {data: userTopArtists, error: userTopArtistsError, isPending: userTopArtistsPending} = useQuerySpotifyUserTopArtists({url: apiEndpoints.spotifyUserTopArtists, key: tkey('spotifyUserTopArtists'), enabled: !!userPlaylists})
-  const {data: userTopTracks, error: userTopTracksError, isPending: userTopTracksPending} = useQuerySpotifyUserTopTracks({url: apiEndpoints.spotifyUserTopTracks, key: tkey('spotifyUserTopTracks'), enabled: !!userTopArtists})
-  const {data: userAllTimeTopArtists, error: userAllTimeTopArtistsError, isPending: userAllTimeTopArtistsPending} = useQuerySpotifyUserTopArtists({url: apiEndpoints.spotifyUserAllTimeTopArtists, key: tkey('spotifyUserAllTimeTopArtists'), enabled: !!userTopTracks })
-  const {data: userAllTimeTopTracks, error: userAllTimeTopTracksError, isPending: userAllTimeTopTracksPending} = useQuerySpotifyUserTopTracks({url: apiEndpoints.spotifyUserAllTimeTopTracks, key: tkey('spotifyUserAllTimeTopTracks'), enabled: !!userAllTimeTopArtists})
+  const { data: userProfile, error: userProfileError, isPending: userProfilePending } = useQuerySpotifyUserProfile({ url: apiEndpoints.spotifyUserProfile, key: tkey('spotifyUserProfile'), enabled: true })
+  const { data: userPlaylists, error: userPlaylistsError, isPending: userPlaylistsPending } = useQuerySpotifyUserPlaylists({ url: apiEndpoints.spotifyUserPlaylists, key: tkey('spotifyUserPlaylists'), enabled: !!userProfile })
+  const { data: userTopArtists, error: userTopArtistsError, isPending: userTopArtistsPending } = useQuerySpotifyUserTopArtists({ url: apiEndpoints.spotifyUserTopArtists, key: tkey('spotifyUserTopArtists'), enabled: !!userPlaylists })
+  const { data: userTopTracks, error: userTopTracksError, isPending: userTopTracksPending } = useQuerySpotifyUserTopTracks({ url: apiEndpoints.spotifyUserTopTracks, key: tkey('spotifyUserTopTracks'), enabled: !!userTopArtists })
+  const { data: userAllTimeTopArtists, error: userAllTimeTopArtistsError, isPending: userAllTimeTopArtistsPending } = useQuerySpotifyUserTopArtists({ url: apiEndpoints.spotifyUserAllTimeTopArtists, key: tkey('spotifyUserAllTimeTopArtists'), enabled: !!userTopTracks })
+  const { data: userAllTimeTopTracks, error: userAllTimeTopTracksError, isPending: userAllTimeTopTracksPending } = useQuerySpotifyUserTopTracks({ url: apiEndpoints.spotifyUserAllTimeTopTracks, key: tkey('spotifyUserAllTimeTopTracks'), enabled: !!userAllTimeTopArtists })
+
   if (userProfilePending) return <LoadingCircle />
-  if (userProfileError?.message == 'Access token expired'){
-    return <ErrorTokenExpired />
-  }
-  if(userProfileError?.message == 'Invalid access token'){
-    return <ErrorInvalidToken />
-  }
+  if (userProfileError?.message == 'Access token expired') {return <ErrorTokenExpired />}
+  if (userProfileError?.message == 'Invalid access token') {return <ErrorInvalidToken />}
+  if (userProfileError?.message == 'There was an error connecting to the server') {return <Error />}
   if (userPlaylistsPending || userTopArtistsPending || userTopTracksPending || userAllTimeTopArtistsPending || userAllTimeTopTracksPending) return <LoadingCircle />
-  if
-  (userProfileError || userPlaylistsError || userTopArtistsError || userTopTracksError || userAllTimeTopArtistsError || userAllTimeTopTracksError) return <Error />
+  if (userProfileError || userPlaylistsError || userTopArtistsError || userTopTracksError || userAllTimeTopArtistsError || userAllTimeTopTracksError) return <Error />
 
   //order of logic is important 
   //have to put the rest of the pending checks after the error handling

--- a/app/src/Pages/PersonalisedSpotify/PersonalisedSpotify.tsx
+++ b/app/src/Pages/PersonalisedSpotify/PersonalisedSpotify.tsx
@@ -9,6 +9,8 @@ import { LoadingCircle } from "../../Components/LoadingCircle";
 import { useQuerySpotifyUserPlaylists, useQuerySpotifyUserProfile, useQuerySpotifyUserTopArtists, useQuerySpotifyUserTopTracks } from "../../Hooks/useQueryGet";
 import { apiEndpoints } from "../../Store/Endpoints";
 import { Error } from "../Error/Error";
+import { ErrorTokenExpired } from "./ErrorTokenExpired";
+import { ErrorInvalidToken } from "./ErrorInvalidToken";
 
 const PersonalisedSpotify: React.FC = () => {
 
@@ -21,8 +23,22 @@ const PersonalisedSpotify: React.FC = () => {
   const {data: userTopTracks, error: userTopTracksError, isPending: userTopTracksPending} = useQuerySpotifyUserTopTracks({url: apiEndpoints.spotifyUserTopTracks, key: tkey('spotifyUserTopTracks'), enabled: !!userTopArtists})
   const {data: userAllTimeTopArtists, error: userAllTimeTopArtistsError, isPending: userAllTimeTopArtistsPending} = useQuerySpotifyUserTopArtists({url: apiEndpoints.spotifyUserAllTimeTopArtists, key: tkey('spotifyUserAllTimeTopArtists'), enabled: !!userTopTracks })
   const {data: userAllTimeTopTracks, error: userAllTimeTopTracksError, isPending: userAllTimeTopTracksPending} = useQuerySpotifyUserTopTracks({url: apiEndpoints.spotifyUserAllTimeTopTracks, key: tkey('spotifyUserAllTimeTopTracks'), enabled: !!userAllTimeTopArtists})
-  if (userProfilePending || userPlaylistsPending || userTopArtistsPending || userTopTracksPending || userAllTimeTopArtistsPending || userAllTimeTopTracksPending) return <LoadingCircle />
-  if (userProfileError || userPlaylistsError || userTopArtistsError || userTopTracksError || userAllTimeTopArtistsError || userAllTimeTopTracksError) return <Error />
+  if (userProfilePending) return <LoadingCircle />
+  if (userProfileError?.message == 'Access token expired'){
+    return <ErrorTokenExpired />
+  }
+  if(userProfileError?.message == 'Invalid access token'){
+    return <ErrorInvalidToken />
+  }
+  if (userPlaylistsPending || userTopArtistsPending || userTopTracksPending || userAllTimeTopArtistsPending || userAllTimeTopTracksPending) return <LoadingCircle />
+  if
+  (userProfileError || userPlaylistsError || userTopArtistsError || userTopTracksError || userAllTimeTopArtistsError || userAllTimeTopTracksError) return <Error />
+
+  //order of logic is important 
+  //have to put the rest of the pending checks after the error handling
+  //as the page loads, all the requests are pending - so if the above is put before the error checking, the page will continually show a loading circle, as all the requests 
+  //will be on pending, returning the loading circle 
+
 
   return (
     <MainContainer>

--- a/app/src/Pages/PersonalisedSpotify/PersonalisedSpotify.tsx
+++ b/app/src/Pages/PersonalisedSpotify/PersonalisedSpotify.tsx
@@ -17,25 +17,20 @@ const PersonalisedSpotify: React.FC = () => {
   const { t } = useTranslation("personalisedSpotify");
   const { t: tkey } = useTranslation("queryKeys")
 
-  const { data: userProfile, error: userProfileError, isPending: userProfilePending } = useQuerySpotifyUserProfile({ url: apiEndpoints.spotifyUserProfile, key: tkey('spotifyUserProfile'), enabled: true })
-  const { data: userPlaylists, error: userPlaylistsError, isPending: userPlaylistsPending } = useQuerySpotifyUserPlaylists({ url: apiEndpoints.spotifyUserPlaylists, key: tkey('spotifyUserPlaylists'), enabled: !!userProfile })
-  const { data: userTopArtists, error: userTopArtistsError, isPending: userTopArtistsPending } = useQuerySpotifyUserTopArtists({ url: apiEndpoints.spotifyUserTopArtists, key: tkey('spotifyUserTopArtists'), enabled: !!userPlaylists })
-  const { data: userTopTracks, error: userTopTracksError, isPending: userTopTracksPending } = useQuerySpotifyUserTopTracks({ url: apiEndpoints.spotifyUserTopTracks, key: tkey('spotifyUserTopTracks'), enabled: !!userTopArtists })
-  const { data: userAllTimeTopArtists, error: userAllTimeTopArtistsError, isPending: userAllTimeTopArtistsPending } = useQuerySpotifyUserTopArtists({ url: apiEndpoints.spotifyUserAllTimeTopArtists, key: tkey('spotifyUserAllTimeTopArtists'), enabled: !!userTopTracks })
-  const { data: userAllTimeTopTracks, error: userAllTimeTopTracksError, isPending: userAllTimeTopTracksPending } = useQuerySpotifyUserTopTracks({ url: apiEndpoints.spotifyUserAllTimeTopTracks, key: tkey('spotifyUserAllTimeTopTracks'), enabled: !!userAllTimeTopArtists })
+  const { data: userProfile, error: userProfileError, isPending: userProfilePending, isInitialLoading: userProfileLoading   } = useQuerySpotifyUserProfile({ url: apiEndpoints.spotifyUserProfile, key: tkey('spotifyUserProfile'), enabled: true })
+  const { data: userPlaylists, error: userPlaylistsError, isPending: userPlaylistsPending, isInitialLoading: userPLaylistsLoading } = useQuerySpotifyUserPlaylists({ url: apiEndpoints.spotifyUserPlaylists, key: tkey('spotifyUserPlaylists'), enabled: !!userProfile })
+  const { data: userTopArtists, error: userTopArtistsError, isPending: userTopArtistsPending, isInitialLoading: userTopArtistsLoading  } = useQuerySpotifyUserTopArtists({ url: apiEndpoints.spotifyUserTopArtists, key: tkey('spotifyUserTopArtists'), enabled: !!userPlaylists })
+  const { data: userTopTracks, error: userTopTracksError, isPending: userTopTracksPending, isInitialLoading: userTopTracksLoading  } = useQuerySpotifyUserTopTracks({ url: apiEndpoints.spotifyUserTopTracks, key: tkey('spotifyUserTopTracks'), enabled: !!userTopArtists })
+  const { data: userAllTimeTopArtists, error: userAllTimeTopArtistsError, isPending: userAllTimeTopArtistsPending, isInitialLoading: userAllTimeTopArtistsLoading  } = useQuerySpotifyUserTopArtists({ url: apiEndpoints.spotifyUserAllTimeTopArtists, key: tkey('spotifyUserAllTimeTopArtists'), enabled: !!userTopTracks })
+  const { data: userAllTimeTopTracks, error: userAllTimeTopTracksError, isPending: userAllTimeTopTracksPending, isInitialLoading: userAllTimeTopTracksLoading  } = useQuerySpotifyUserTopTracks({ url: apiEndpoints.spotifyUserAllTimeTopTracks, key: tkey('spotifyUserAllTimeTopTracks'), enabled: !!userAllTimeTopArtists })
 
-  if (userProfilePending) return <LoadingCircle />
   if (userProfileError?.message == 'Access token expired') {return <ErrorTokenExpired />}
   if (userProfileError?.message == 'Invalid access token') {return <ErrorInvalidToken />}
   if (userProfileError?.message == 'There was an error connecting to the server') {return <Error />}
-  if (userPlaylistsPending || userTopArtistsPending || userTopTracksPending || userAllTimeTopArtistsPending || userAllTimeTopTracksPending) return <LoadingCircle />
-  if (userProfileError || userPlaylistsError || userTopArtistsError || userTopTracksError || userAllTimeTopArtistsError || userAllTimeTopTracksError) return <Error />
+  if(userProfileLoading || userPLaylistsLoading || userTopArtistsLoading || userTopTracksLoading || userAllTimeTopArtistsLoading || userAllTimeTopTracksLoading) return <LoadingCircle />
+  if (userPlaylistsError || userTopArtistsError || userTopTracksError || userAllTimeTopArtistsError || userAllTimeTopTracksError) return <Error />
 
-  //order of logic is important 
-  //have to put the rest of the pending checks after the error handling
-  //as the page loads, all the requests are pending - so if the above is put before the error checking, the page will continually show a loading circle, as all the requests 
-  //will be on pending, returning the loading circle 
-
+  //isPending vs isInitialLoading for loading circle to appear - see documentation 
 
   return (
     <MainContainer>

--- a/app/src/Store/Endpoints.ts
+++ b/app/src/Store/Endpoints.ts
@@ -8,11 +8,11 @@ if (process.env.NODE_ENV === 'development'){
 
 export const apiEndpoints = {
     spotifyUserTopTracks: `https://api.spotify.com/v1/me/top/tracks?limit=${10}`,
-    spotifyAllTimeUserTopTracks: `https://api.spotify.com/v1/me/top/tracks?limit=${10}&time_range=long_term`,
+    spotifyUserAllTimeTopTracks: `https://api.spotify.com/v1/me/top/tracks?limit=${10}&time_range=long_term`,
     spotifyTokenRequest: 'https://accounts.spotify.com/api/token',
     spotifyUserProfile: 'https://api.spotify.com/v1/me',
     spotifyUserTopArtists: `https://api.spotify.com/v1/me/top/artists?limit=${10}`,
-    spotifyAllTimeUserTopArtists: `https://api.spotify.com/v1/me/top/artists?limit=${10}&time_range=long_term`,
+    spotifyUserAllTimeTopArtists: `https://api.spotify.com/v1/me/top/artists?limit=${10}&time_range=long_term`,
     spotifyUserPlaylists: `https://api.spotify.com/v1/me/playlists?limit=${10}`,
     products: `${apiUrl}/product`,
 }

--- a/app/src/Store/SpotifyAPI/Requests/getAllTimeUserTopArtists.ts
+++ b/app/src/Store/SpotifyAPI/Requests/getAllTimeUserTopArtists.ts
@@ -3,7 +3,7 @@ import { yieldGet } from "../../apiStore";
 
 function* getAllTimeUserTopArtists() {
   const accessToken = localStorage.getItem("access_token");
-  const userTopArtistsUrl = apiEndpoints.spotifyAllTimeUserTopArtists;
+  const userTopArtistsUrl = apiEndpoints.spotifyUserAllTimeTopArtists;
   try {
     // @ts-ignore
     const response = yield yieldGet(userTopArtistsUrl, { Authorization: "Bearer " + accessToken,})

--- a/app/src/Store/SpotifyAPI/Requests/getAllTimeUserTopTracks.ts
+++ b/app/src/Store/SpotifyAPI/Requests/getAllTimeUserTopTracks.ts
@@ -3,7 +3,7 @@ import { yieldGet } from "../../apiStore";
 
 function* getAllTimeUserTopTracks() {
   const accessToken = localStorage.getItem("access_token");
-  const userTopTracksUrl = apiEndpoints.spotifyAllTimeUserTopTracks;
+  const userTopTracksUrl = apiEndpoints.spotifyUserAllTimeTopTracks;
   try {
     // @ts-ignore
     const response = yield yieldGet(userTopTracksUrl, {Authorization: "Bearer " + accessToken,})

--- a/app/src/Store/apiStore.ts
+++ b/app/src/Store/apiStore.ts
@@ -23,7 +23,7 @@ export const get = async (url: string, header?: object) => {
           return response.data;
         }
     catch (error){
-        console.error(error)
+      throw error
     }
   }
 

--- a/app/src/Store/apiStore.ts
+++ b/app/src/Store/apiStore.ts
@@ -1,4 +1,5 @@
-import axios from "axios";
+import axios, { AxiosResponse } from "axios";
+import { spotifyRefreshTokenResponse } from "../Constants/Types/Spotify";
 
 export const yieldGet = (url: string, header?: object) => {
     if (header) {
@@ -16,11 +17,11 @@ export const yieldGet = (url: string, header?: object) => {
     }
 }
 
-export const get = async (url: string) => {
+export const get = async (url: string, header?: object) => {
     try{
-        const response = await axios.get(url);
-        return response.data;
-    }
+        const response = await axios.get(url, {headers: header});
+          return response.data;
+        }
     catch (error){
         console.error(error)
     }
@@ -56,36 +57,21 @@ export const post = async (url: string, payload: any) => {
     }
   } 
 
+  export const spotifyPost = async (url: string, payload: any) => {
+    try{
+      const response: AxiosResponse<spotifyRefreshTokenResponse> = await axios.post(url, payload, {headers:{ "Content-Type": "application/x-www-form-urlencoded"}});
+      return response.data;
+    }
+    catch(error){
+      console.error(error)
+    }
+  } 
 
-// below doesn't currently work for the refresh token POST request...something to look at another time....
+  //AxiosResponse by default is <any, any>, <data, headers>
+  //Where this is referenced in my mutation, i need to set local storage to items from the data returned 
+  //So have to change the data type that is returnd from 'any' to the specific data you expect to receive
+  //Otherwise error occurs saying it can't access data.[variable], as it doesn't exist on type AxiosResponse<any, any>
+  //With type change, it is now: AxiosResponse<RefreshTokenResponse, eny>
 
-// export const yieldPost = (url: string, header?: object, body?: object) => {
-//     const requestOptions: RequestInit = {
-//         method: 'POST',
-//     }
-//     if (header) {
-//         console.log('1')
-//         const headersArray = Object.entries(header);
-//         requestOptions.headers = headersArray;
-//     }
-//     if (body) {
-//         console.log('2')
-//         if (body instanceof URLSearchParams) {
-//             // If the body is an instance of URLSearchParams, convert it to a string
-//             requestOptions.body = body.toString();
-//         }
-//         else {
-//             console.log('3')
-//             requestOptions.body = JSON.stringify(body)
-//         }
-//     }
-//     return fetch(url, requestOptions)
-// }
-
-//there is something about formatting the body to a string 
-//depends on the content type the server is expecting 
-//if passing in URLSearchParams you use .toString 
-//if passing in a standard object (e.g. a payload for the backend), then use JSON.stringify on it
-//NOTE: payload/body are the same thing
 
 


### PR DESCRIPTION
- Refactored Spotify requests to use useQuery 
- updated axios get request to accept header as a prop 
- Added new useQueries for spotify requests (so that I could format the data as needed for each)
- Passed props as a destructured object (co can specify which props to include when referencing them)
- Updated 'enabled' option on query to make them be called one after another 
- Make use of isInitialLoading over isPending to make loading circle appear 
- try/catch statement in axios get request, so i can catch errors in my query if needed, to pass custom errors (custom error pages shown based on message, e.g. invalid/expired access token) 